### PR TITLE
Fix TCEMAIN settings not being loaded

### DIFF
--- a/Classes/SlugModifier.php
+++ b/Classes/SlugModifier.php
@@ -89,7 +89,7 @@ class SlugModifier
      */
     protected function resolveHookParameters(array $configuration, $tableName, $fieldName, $pid, $workspaceId, $record)
     {
-        $overrides = BackendUtility::getPagesTSconfig($pid)['TCEMAIN.'][$tableName][$fieldName] ?? [];
+        $overrides = BackendUtility::getPagesTSconfig($pid)['TCEMAIN.'][$tableName . '.'][$fieldName . '.'] ?? [];
         $this->configuration = array_replace_recursive($configuration, $overrides);
         $this->tableName = $tableName;
         $this->fieldName = $fieldName;


### PR DESCRIPTION
Overrides were tried to be loaded via ['TCEMAIN.'][$tableName][$fieldName], missing the trailing . behind $tableName and $fieldName, resulting in the overrides always being empty.
This patch adds the dots.