### PR TITLE
Fix incorrect TCEMAIN settings merge

### DIFF
--- a/Classes/SlugModifier.php
+++ b/Classes/SlugModifier.php
@@ -12,6 +12,7 @@ namespace B13\Masi;
 
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\DataHandling\SlugHelper;
+use TYPO3\CMS\Core\TypoScript\TypoScriptService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -90,6 +91,17 @@ class SlugModifier
     protected function resolveHookParameters(array $configuration, $tableName, $fieldName, $pid, $workspaceId, $record)
     {
         $overrides = BackendUtility::getPagesTSconfig($pid)['TCEMAIN.'][$tableName . '.'][$fieldName . '.'] ?? [];
+        if ($overrides) {
+            $typoscriptService = GeneralUtility::makeInstance(TypoScriptService::class);
+            $overrides = $typoscriptService->convertTypoScriptArrayToPlainArray(
+                $overrides
+            );
+            if (isset($overrides['generatorOptions']['fields'])) {
+                $overrides['generatorOptions']['fields'] = array_unique(
+                    GeneralUtility::trimExplode(',', $overrides['generatorOptions']['fields'], true)
+                );
+            }
+        }
         $this->configuration = array_replace_recursive($configuration, $overrides);
         $this->tableName = $tableName;
         $this->fieldName = $fieldName;

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ There is a CLI command to migrate the options from RealURL to the _masi_ databas
 3. _masi_ evaluates PageTSconfig where you can override your values.
 
         TCEMAIN.pages.slug.generatorOptions {
-            generatorOptions.fields = company, city
+            fields = company, city
             fieldSeparator = -
         }
 


### PR DESCRIPTION
Array keys of $configuration are without trailing dots, while $overrides are with trailing dots.
Naturally, as such, the merge of the two made no sense.

$overrides are now processed with convertTypoScriptArrayToPlainArray before merging them.

Additionally, the fields setting is supposed to be an array, but was a string. This is now exploded into an array before merge.