### PR TITLE
Fix position of field 'exclude_slug_for_subpages'

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -26,4 +26,4 @@ $additionalColumns = [
 ];
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $additionalColumns);
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', 'exclude_slug_for_subpages', '', 'after:slug');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette('pages', 'title', 'exclude_slug_for_subpages', 'after:slug');


### PR DESCRIPTION
The new field 'exclude_slug_for_subpages' should be placed within the palette 'title', after field 'slug'.