### PR TITLE
Add migration command as upgrade wizard

### DIFF
--- a/Classes/SlugModifier.php
+++ b/Classes/SlugModifier.php
@@ -193,7 +193,7 @@ class SlugModifier
         $parentPageRecord = null;
         $rootLine = BackendUtility::BEgetRootLine($pid, '', true, ['nav_title', 'exclude_slug_for_subpages']);
         do {
-            $parentPageRecord = array_shift($rootLine);
+            $parentPageRecord = array_shift($rootLine) ?? [];
             $parentPageRecord = $this->tryRecordOverlay($parentPageRecord, $languageId);
             $excludeThisPageRecordForSubpages = (bool)$parentPageRecord['exclude_slug_for_subpages'];
         } while (!empty($rootLine) && ((int)$parentPageRecord['doktype'] === 255 || $excludeThisPageRecordForSubpages));

--- a/Classes/Updates/MigrateRealUrlExcludeField.php
+++ b/Classes/Updates/MigrateRealUrlExcludeField.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace B13\Masi\Updates;
+
+/*
+ * This file is part of TYPO3 CMS-extension masi by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
+
+/**
+ * Command for migrating fields from "pages.tx_realurl_exclude"
+ * into "pages.exclude_slug_for_subpages".
+ */
+class MigrateRealUrlExcludeField implements UpgradeWizardInterface
+{
+    public function getIdentifier(): string
+    {
+        return 'masiMigrateRealUrlExclude';
+    }
+
+    public function getTitle(): string
+    {
+        return 'Masi - Migrate RealUrl exclude field';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Masi - Migrate RealUrl pages.tx_realurl_exclude field to Masi pages.exclude_slug_for_subpages';
+    }
+
+    public function executeUpdate(): bool
+    {
+        $conn = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('pages');
+
+        $queryBuilder = $conn->createQueryBuilder();
+        $queryBuilder->getRestrictions()->removeAll();
+        $existingRows = $queryBuilder
+            ->select('uid')
+            ->from('pages')
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'tx_realurl_exclude',
+                    $queryBuilder->createNamedParameter(1, \PDO::PARAM_INT)
+                )
+            )
+            ->execute()
+            ->fetchAll();
+
+        $existingPages = array_column($existingRows, 'uid');
+
+        $conn->createQueryBuilder()
+            ->update('pages')
+            ->set('exclude_slug_for_subpages', 1)
+            ->where(
+                $queryBuilder->expr()->in(
+                    'uid',
+                    // do not use named parameter here as the list can get too long
+                    $existingPages
+                ),
+                $queryBuilder->expr()->in(
+                    'l10n_parent',
+                    array_merge($existingPages, [0])
+                )
+            )
+            ->execute();
+
+        return true;
+    }
+
+    public function updateNecessary(): bool
+    {
+        $conn = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('pages');
+        $columns = $conn->getSchemaManager()->listTableColumns('pages');
+        foreach ($columns as $column) {
+            if (strtolower($column->getName()) === 'tx_realurl_exclude') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function getPrerequisites(): array
+    {
+        return [
+            DatabaseUpdatedPrerequisite::class
+        ];
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,0 +1,7 @@
+<?php
+
+/**
+ * Registering Upgrade Wizards
+ */
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['masiMigrateRealUrlExclude']
+    = \B13\Masi\Updates\MigrateRealUrlExcludeField::class;


### PR DESCRIPTION
I've added the migration command as upgrade wizard. This comes in handy while one is doing an upgrade of their TYPO3 installation. In my case, I am working on an upgrade and walked into to the problem that the `PopulatePageSlugs` included in the TYPO3 install package was generating incorrect slugs due to the missing feature of including and excluding slugs from Folders and Menu Separators.

This extension solved my problems and after reïmporting an unmigrated database, executing this migration command manually and executing my upgrade script which includes all upgrade wizards in the correct order, the page slugs were like the URLs I had before.

Because I wanted to be able to extending my upgrade script with this migration command, I decided to add an upgrade wizard based on the code in the migration command.

I ran into one issue where the `array_shift` method inside the `SlugModifier` class is returning `null` for deleted pages, which causes the `tryRecordOverlay` function to crash because it expects the first argument to be an array, not `null`. That's the reason I used the null coalescing operator to set `$parentPageRecord` to an empty array instead of `null`.