### PR TITLE
[BUGFIX] Add return type to MigrateFieldsCommand::execute()

### DIFF
--- a/Classes/Command/MigrateFieldsCommand.php
+++ b/Classes/Command/MigrateFieldsCommand.php
@@ -86,6 +86,8 @@ class MigrateFieldsCommand extends Command
         } else {
             $io->note('Nothing done, as the database field "pages.tx_realurl_exclude" does not exist.');
         }
+        
+        return 0;
     }
 
     /**


### PR DESCRIPTION
It fixes: Uncaught TYPO3 Exception Return value of "B13\Masi\Command\MigrateFieldsCommand::execute()" must be of the type int, "null" returned.