### PR TITLE
Improve UX by avoiding to shorten slug field

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -25,5 +25,5 @@ $additionalColumns = [
 ];
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $additionalColumns);
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette('pages', 'title', 'exclude_slug_for_subpages', 'after:slug');
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette('pages', 'titleonly', 'exclude_slug_for_subpages', 'after:slug');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette('pages', 'title', '--linebreak--,exclude_slug_for_subpages', 'after:slug');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette('pages', 'titleonly', '--linebreak--,exclude_slug_for_subpages', 'after:slug');


### PR DESCRIPTION
The new field exclude_slug_for_subpages is placed after the slug and by default the slug field is shortened and the new field is placed right after the slug field. Now longer slug are not completely visible anymore, which is a real hassle for editors. If we add the proposed linebreak, the slug field can use the whole space again.