### PR TITLE
[BUGFIX] Upgrade wizard SQL error when there is nothing to migrate

### DIFF
--- a/Classes/Updates/MigrateRealUrlExcludeField.php
+++ b/Classes/Updates/MigrateRealUrlExcludeField.php
@@ -38,7 +38,7 @@ class MigrateRealUrlExcludeField implements UpgradeWizardInterface
         return 'Masi - Migrate RealUrl pages.tx_realurl_exclude field to Masi pages.exclude_slug_for_subpages';
     }
 
-    protected function getExistingExcludedPages()
+    protected function getExistingExcludedPages(): array
     {
         $conn = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('pages');
         $queryBuilder = $conn->createQueryBuilder();
@@ -100,11 +100,11 @@ class MigrateRealUrlExcludeField implements UpgradeWizardInterface
 
     /**
      * Upgrade is necessary if the environment has the "tx_realurl_exclude" column and
-     * there is any page where has this set to "1", else skip the wizard
+     * there is at least one page having this field set to "1", else skip the wizard
      */
     public function updateNecessary(): bool
     {
-        return ($this->doesRealurlFieldExist() && count($this->getExistingExcludedPages()) > 0);
+        return $this->doesRealurlFieldExist() && count($this->getExistingExcludedPages()) > 0;
     }
 
     public function getPrerequisites(): array

--- a/Classes/Updates/MigrateRealUrlExcludeField.php
+++ b/Classes/Updates/MigrateRealUrlExcludeField.php
@@ -38,10 +38,9 @@ class MigrateRealUrlExcludeField implements UpgradeWizardInterface
         return 'Masi - Migrate RealUrl pages.tx_realurl_exclude field to Masi pages.exclude_slug_for_subpages';
     }
 
-    public function executeUpdate(): bool
+    protected function getExistingExcludedPages()
     {
         $conn = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('pages');
-
         $queryBuilder = $conn->createQueryBuilder();
         $queryBuilder->getRestrictions()->removeAll();
         $existingRows = $queryBuilder
@@ -55,8 +54,18 @@ class MigrateRealUrlExcludeField implements UpgradeWizardInterface
             )
             ->execute()
             ->fetchAll();
+        
+        return array_column($existingRows, 'uid'); 
 
-        $existingPages = array_column($existingRows, 'uid');
+    }
+    
+    public function executeUpdate(): bool
+    {
+        $conn = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('pages');
+        $queryBuilder = $conn->createQueryBuilder();
+        $queryBuilder->getRestrictions()->removeAll();
+
+        $existingPages = $this->getExistingExcludedPages();
 
         $conn->createQueryBuilder()
             ->update('pages')
@@ -77,7 +86,7 @@ class MigrateRealUrlExcludeField implements UpgradeWizardInterface
         return true;
     }
 
-    public function updateNecessary(): bool
+    protected function doesRealurlFieldExist(): bool
     {
         $conn = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('pages');
         $columns = $conn->getSchemaManager()->listTableColumns('pages');
@@ -87,6 +96,15 @@ class MigrateRealUrlExcludeField implements UpgradeWizardInterface
             }
         }
         return false;
+    }
+
+    /**
+     * Upgrade is necessary if the environment has the "tx_realurl_exclude" column and
+     * there is any page where has this set to "1", else skip the wizard
+     */
+    public function updateNecessary(): bool
+    {
+        return ($this->doesRealurlFieldExist() && count($this->getExistingExcludedPages()) > 0);
     }
 
     public function getPrerequisites(): array


### PR DESCRIPTION
In a real-world scenario where there is the field `tx_realurl_exclude` field but it's not set on any page, the upgrade wizard gets stuck with this error:

```
$ bin/typo3cms upgrade:run masiMigrateRealUrlExclude

                                                                                                                                      
  [ Doctrine\DBAL\Exception\SyntaxErrorException ]                                                                                    
  An exception occurred while executing 'UPDATE `pages` SET `exclude_slug_for_subpages` = ? WHERE (`uid` IN ()) AND (`l10n_parent` I  
  N (0))' with params [1]:                                                                                                            
                                                                                                                                      
  You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use  
   near ')) AND (`l10n_parent` IN (0))' at line 1                                                                                     
                                                                                                                                      

Caused by:
                                                                                                                                      
  [ Doctrine\DBAL\Driver\Mysqli\Exception\ConnectionError ]                                                                           
  You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use  
   near ')) AND (`l10n_parent` IN (0))' at line 1                                                                                     
                                                                                                                                      

Caused by:
                                                                                                                                      
  [ mysqli_sql_exception ]                                                                                                            
  You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use  
   near ')) AND (`l10n_parent` IN (0))' at line 1                                                                                     
```
