### PR TITLE
[BUGFIX] fix incoming record being overwritten from DB, stringify pieces

### DIFF
--- a/Classes/SlugModifier.php
+++ b/Classes/SlugModifier.php
@@ -92,7 +92,7 @@ class SlugModifier
                 $row = $stm->fetchAssociative();
             }
             if ($row !== false) {
-                $this->recordData = $row;
+                $this->recordData = array_replace($row, $record);
             }
         }
 
@@ -137,7 +137,7 @@ class SlugModifier
             }
             foreach ($fieldNameParts as $fieldName) {
                 if (!empty($this->recordData[$fieldName])) {
-                    $pieceOfSlug = $this->recordData[$fieldName];
+                    $pieceOfSlug = (string)$this->recordData[$fieldName];
                     $pieceOfSlug = str_replace(
                         array_keys($replaceConfiguration),
                         array_values($replaceConfiguration),


### PR DESCRIPTION
This fixes #33 by applying `array_replace` to the loaded record array with the incoming record fields.

Also apply string casting to the slug pieces to avoid fatal error when some other hook sets a record field as something else than string, e.g. integer.