### PR TITLE
[TASK] Use Connection instead of PDO

### DIFF
--- a/Classes/Command/MigrateFieldsCommand.php
+++ b/Classes/Command/MigrateFieldsCommand.php
@@ -50,7 +50,7 @@ class MigrateFieldsCommand extends Command
                 ->select('uid')
                 ->from('pages')
                 ->where(
-                    $queryBuilder->expr()->eq('tx_realurl_exclude', $queryBuilder->createNamedParameter(1, \PDO::PARAM_INT))
+                    $queryBuilder->expr()->eq('tx_realurl_exclude', $queryBuilder->createNamedParameter(1, Connection::PARAM_INT))
                 )
                 ->execute()
                 ->fetchAll();

--- a/Classes/SlugModifier.php
+++ b/Classes/SlugModifier.php
@@ -12,6 +12,7 @@ namespace B13\Masi;
  */
 
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\SlugHelper;
 use TYPO3\CMS\Core\Information\Typo3Version;
@@ -83,7 +84,7 @@ class SlugModifier
             $stm = $queryBuilder->select('*')
                 ->from('pages')
                 ->where(
-                    $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($record['uid'], \PDO::PARAM_INT))
+                    $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($record['uid'], Connection::PARAM_INT))
                 )
                 ->execute();
             if ((GeneralUtility::makeInstance(Typo3Version::class))->getMajorVersion() === 10) {

--- a/Classes/Updates/MigrateRealUrlExcludeField.php
+++ b/Classes/Updates/MigrateRealUrlExcludeField.php
@@ -12,6 +12,7 @@ namespace B13\Masi\Updates;
  * of the License, or any later version.
  */
 
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
@@ -49,7 +50,7 @@ class MigrateRealUrlExcludeField implements UpgradeWizardInterface
             ->where(
                 $queryBuilder->expr()->eq(
                     'tx_realurl_exclude',
-                    $queryBuilder->createNamedParameter(1, \PDO::PARAM_INT)
+                    $queryBuilder->createNamedParameter(1, Connection::PARAM_INT)
                 )
             )
             ->execute()


### PR DESCRIPTION
In Doctrine DBAL v4, as described in the [documentation](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Database/QueryBuilder/Index.html#database-query-builder-create-named-parameter), support for using the `\PDO::PARAM_*` constants has been dropped in favor of the enum types. This should be migrated to `Connection::PARAM_*` in order to be compatible with TYPO3 v13 later on. `Connection::PARAM_*` can already be used now as it is compatible with TYPO3 11 and 12.