### PR TITLE
[BUGFIX] Mitigate internal SchemaInformation API changes

### DIFF
--- a/Classes/Command/MigrateFieldsCommand.php
+++ b/Classes/Command/MigrateFieldsCommand.php
@@ -94,10 +94,18 @@ class MigrateFieldsCommand extends Command
      */
     protected function doesRealurlFieldExist(Connection $conn): bool
     {
-        $columns = $conn->getSchemaInformation()->introspectTable('pages')->getColumns();
-        foreach ($columns as $column) {
-            if (strtolower($column->getName()) === 'tx_realurl_exclude') {
-                return true;
+        $realurlFieldName = 'tx_realurl_exclude';
+        $schemaInformation = $conn->getSchemaInformation();
+        if (method_exists($schemaInformation, 'listTableColumnNames')) {
+            // TYPO3 13.4.19 and higher
+            return in_array($realurlFieldName, $schemaInformation->listTableColumnNames('pages'), true);
+        } else if (method_exists($schemaInformation, 'introspectTable')) {
+            // Before TYPO3 v13.4.19
+            $columns = $schemaInformation->introspectTable('pages')->getColumns();
+            foreach ($columns as $column) {
+                if ($column->getName() === $realurlFieldName) {
+                    return true;
+                }
             }
         }
         return false;

--- a/Classes/Updates/MigrateRealUrlExcludeField.php
+++ b/Classes/Updates/MigrateRealUrlExcludeField.php
@@ -90,13 +90,23 @@ class MigrateRealUrlExcludeField implements UpgradeWizardInterface
 
     protected function doesRealurlFieldExist(): bool
     {
+        $realurlFieldName = 'tx_realurl_exclude';
         $conn = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('pages');
-        $columns = $conn->getSchemaInformation()->introspectTable('pages')->getColumns();
-        foreach ($columns as $column) {
-            if (strtolower($column->getName()) === 'tx_realurl_exclude') {
-                return true;
+        $schemaInformation = $conn->getSchemaInformation();
+
+        if (method_exists($schemaInformation, 'listTableColumnNames')) {
+            // TYPO3 13.4.19 and higher
+            return in_array($realurlFieldName, $schemaInformation->listTableColumnNames('pages'), true);
+        } else if (method_exists($schemaInformation, 'introspectTable')) {
+            // Before TYPO3 v13.4.19
+            $columns = $schemaInformation->introspectTable('pages')->getColumns();
+            foreach ($columns as $column) {
+                if ($column->getName() === $realurlFieldName) {
+                    return true;
+                }
             }
         }
+
         return false;
     }
 


### PR DESCRIPTION
TYPO3 changed the internal SchemaInformation API implementation,
not covered by breaking policy to mitigate cache issues using
persistance caches files.

This change modifies the extension usage of that internal API
in the `MigrateFieldsCommand ` and `MigrateRealUrlExcludeField`
by now using the `listTableColumnNames()` to retrieve the names of
the columns for further use.

Further, the `strtolower()` usage in the fieldname comparision
has been removed making not much sense in the way that other
code places does use field names as case-insensitive like in
result rowset row items.

[1] https://review.typo3.org/c/Packages/TYPO3.CMS/+/90947
[2] https://review.typo3.org/c/Packages/TYPO3.CMS/+/90950